### PR TITLE
Support nil UUID

### DIFF
--- a/ValidatorSpec.js
+++ b/ValidatorSpec.js
@@ -12,6 +12,9 @@ describe('uuid validator', function () {
     it('accepts implicit valid uuidv4', function () {
         expect(validate('09bb1d8c-4965-4788-94f7-31b151eaba4e')).toBe(true);
     });
+    it('accepts nil uuid', function () {
+      expect(validate('00000000-0000-0000-0000-000000000000')).toBe(true);
+    });
     it('denies if wrong version', function () {
         expect(validate('23d57c30-afe7-11e4-ab7d-12e3f512a338', 4)).toBe(false);
     });

--- a/index.js
+++ b/index.js
@@ -54,6 +54,11 @@ module.exports = function (uuid, version) {
 
     parsedUuid = parsedUuid.toLowerCase();
 
+    // Defined in RFC 4122, nil UUID is a special form of UUID with all zeros.
+    if (uuid === '00000000-0000-0000-0000-000000000000') {
+      return true;
+    }
+
     // All UUIDs fit a basic schema. Match that.
     if (!pattern.test(parsedUuid)) {
         return false;


### PR DESCRIPTION
https://tools.ietf.org/html/rfc4122#section-4.1.7
>  The nil UUID is special form of UUID that is specified to have all
   128 bits set to zero.